### PR TITLE
defaultAnswer(CALLS_REAL_METHODS) for defaultMock

### DIFF
--- a/slf4j-mock-common/src/main/java/org/simplify4u/slf4jmock/LoggerMock.java
+++ b/slf4j-mock-common/src/main/java/org/simplify4u/slf4jmock/LoggerMock.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
@@ -43,7 +44,7 @@ public final class LoggerMock {
         return (Logger) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
                 new Class<?>[]{Logger.class, ProxyMock.class},
                 new MockInvocationHandler(name, () ->
-                        mock(SimpleLogger.class, withSettings().spiedInstance(new SimpleLogger(name)).stubOnly())
+                        mock(SimpleLogger.class, withSettings().spiedInstance(new SimpleLogger(name)).defaultAnswer(CALLS_REAL_METHODS).stubOnly())
                 )
         );
     }

--- a/slf4j-mock-common/src/main/java/org/simplify4u/slf4jmock/LoggerMock.java
+++ b/slf4j-mock-common/src/main/java/org/simplify4u/slf4jmock/LoggerMock.java
@@ -36,15 +36,16 @@ public final class LoggerMock {
 
     private static final Map<String, Logger> loggers = new HashMap<>();
 
-    private LoggerMock(){
+    private LoggerMock() {
         // Utility classes
     }
 
     private static Logger createNewLoggerProxy(String name) {
         return (Logger) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
-                new Class<?>[]{Logger.class, ProxyMock.class},
+                new Class<?>[] {Logger.class, ProxyMock.class},
                 new MockInvocationHandler(name, () ->
-                        mock(SimpleLogger.class, withSettings().spiedInstance(new SimpleLogger(name)).defaultAnswer(CALLS_REAL_METHODS).stubOnly())
+                        mock(SimpleLogger.class, withSettings().spiedInstance(new SimpleLogger(name))
+                                .defaultAnswer(CALLS_REAL_METHODS).stubOnly())
                 )
         );
     }
@@ -67,7 +68,7 @@ public final class LoggerMock {
      * Set Mock for given Logger at current thread.
      *
      * @param klass Logger class
-     * @param mock  Mock to assign to Logger
+     * @param mock Mock to assign to Logger
      */
     public static void setMock(Class<?> klass, Logger mock) {
         setMock(klass.getName(), mock);

--- a/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateExampleTest.java
+++ b/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateExampleTest.java
@@ -17,6 +17,8 @@
 package org.simplify4u.slf4jmock.test;
 
 
+import java.io.File;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.simplify4u.slf4jmock.LoggerMock;
 import org.slf4j.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -40,12 +43,12 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TemplateExampleTest {
 
-    private static final String INFO_TEST_MESSAGE = "info log test message";
+    private static final String INFO_TEST_MESSAGE = "info log test message - ExampleTest";
     private static final String WARN_TEST_MESSAGE = "warn log test message";
     private static final String DEBUG_TEST_MESSAGE = "debug log test message";
     private static final String DEBUG_TEST_FORMAT = "Debug: {}";
 
-    static abstract class ExampleTestCommon {
+    abstract static class ExampleTestCommon {
 
         @Mock
         Logger logger;
@@ -92,6 +95,12 @@ class TemplateExampleTest {
             // then
             verify(logger).info(INFO_TEST_MESSAGE);
             verifyNoMoreInteractions(logger);
+
+            File logFile = new File("target/slf4j-simpleLogger.log");
+            if (logFile.exists()) {
+                assertThat(logFile)
+                        .content().doesNotContain(INFO_TEST_MESSAGE);
+            }
         }
 
         @Test

--- a/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateInitializedSpyLoggerTest.java
+++ b/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateInitializedSpyLoggerTest.java
@@ -16,6 +16,8 @@
 
 package org.simplify4u.slf4jmock.test;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.simplify4u.slf4jmock.SimpleLogger;
 import org.slf4j.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 
@@ -45,10 +48,13 @@ class TemplateInitializedSpyLoggerTest {
     @Test
     void testSpy() {
 
-        sut.methodWithLogInfo("Info message");
+        sut.methodWithLogInfo("Info message - InitializedSpyLoggerTest");
 
-        Mockito.verify(logger1).info("Info message");
+        Mockito.verify(logger1).info("Info message - InitializedSpyLoggerTest");
         Mockito.verify(logger2, never()).info(anyString());
+
+        assertThat(new File("target/slf4j-simpleLogger.log"))
+                .content().contains("Info message - InitializedSpyLoggerTest");
     }
 
 }

--- a/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateSpyLoggerTest.java
+++ b/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateSpyLoggerTest.java
@@ -16,6 +16,8 @@
 
 package org.simplify4u.slf4jmock.test;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +26,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class TemplateSpyLoggerTest {
@@ -37,10 +40,13 @@ class TemplateSpyLoggerTest {
     @Test
     void testSpy() {
 
-        sut.methodWithLogInfo("Info message");
+        sut.methodWithLogInfo("Info message - SpyLoggerTest");
 
-        Mockito.verify(logger).info("Info message");
+        Mockito.verify(logger).info("Info message - SpyLoggerTest");
         Mockito.verifyNoMoreInteractions(logger);
+
+        assertThat(new File("target/slf4j-simpleLogger.log"))
+                .content().contains("Info message - SpyLoggerTest");
     }
 
 }

--- a/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateWithOutMocksTest.java
+++ b/slf4j-mock-tests/src/test/java/org/simplify4u/slf4jmock/test/TemplateWithOutMocksTest.java
@@ -16,6 +16,8 @@
 
 package org.simplify4u.slf4jmock.test;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
@@ -28,8 +30,11 @@ class TemplateWithOutMocksTest {
 
     @Test
     void loggerTest() {
-        assertThatCode(() -> sut.methodWithLogInfo("Some message"))
+        assertThatCode(() -> sut.methodWithLogInfo("Some message - WithOutMocksTest"))
                 .doesNotThrowAnyException();
+
+        assertThat(new File("target/slf4j-simpleLogger.log"))
+                .content().contains("Some message - WithOutMocksTest");
     }
 
     @Test

--- a/slf4j-mock-tests/src/test/resources/simplelogger.properties
+++ b/slf4j-mock-tests/src/test/resources/simplelogger.properties
@@ -16,3 +16,4 @@
 
 
 org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.logFile=target/slf4j-simpleLogger.log


### PR DESCRIPTION
With this PR the defaultAnswer for the defaultMock Spies ist changed to CALLS_REAL_METHOD.
This is the same behaviour as when your create a spy with Mockito.spy(new SimpleLogger(name)).

See issue https://github.com/s4u/slf4j-mock/issues/204

